### PR TITLE
Fixing review comments in deployment

### DIFF
--- a/resume-buddy/src/main/java/com/google/sps/data/Comment.java
+++ b/resume-buddy/src/main/java/com/google/sps/data/Comment.java
@@ -49,10 +49,10 @@ public final class Comment {
 
   /** A comparator for sorting comments by their date. */
   public static final Comparator<Comment> ORDER_BY_DATE =
-    new Comparator<Comment>() {
-      @Override
-      public int compare(Comment a, Comment b) {
-        return (a.getDate()).compareTo(b.getDate());
-      }
-    };
+      new Comparator<Comment>() {
+        @Override
+        public int compare(Comment a, Comment b) {
+          return (b.getDate()).compareTo(a.getDate());
+        }
+      };
 }

--- a/resume-buddy/src/main/java/com/google/sps/data/Comment.java
+++ b/resume-buddy/src/main/java/com/google/sps/data/Comment.java
@@ -1,5 +1,6 @@
 package com.google.sps.data;
 
+import java.util.Comparator;
 import java.util.Date;
 
 /** Class containing comment object that are used on resume-review page */
@@ -45,4 +46,13 @@ public final class Comment {
   public String getId() {
     return id;
   }
+
+  /** A comparator for sorting comments by their date. */
+  public static final Comparator<Comment> ORDER_BY_DATE =
+    new Comparator<Comment>() {
+      @Override
+      public int compare(Comment a, Comment b) {
+        return (a.getDate()).compareTo(b.getDate());
+      }
+    };
 }

--- a/resume-buddy/src/main/java/com/google/sps/data/Comment.java
+++ b/resume-buddy/src/main/java/com/google/sps/data/Comment.java
@@ -49,10 +49,10 @@ public final class Comment {
 
   /** A comparator for sorting comments by their date. */
   public static final Comparator<Comment> ORDER_BY_DATE =
-      new Comparator<Comment>() {
-        @Override
-        public int compare(Comment a, Comment b) {
-          return (b.getDate()).compareTo(a.getDate());
-        }
-      };
+    new Comparator<Comment>() {
+      @Override
+      public int compare(Comment a, Comment b) {
+        return (b.getDate()).compareTo(a.getDate());
+      }
+    };
 }

--- a/resume-buddy/src/main/java/com/google/sps/servlets/CommentServlet.java
+++ b/resume-buddy/src/main/java/com/google/sps/servlets/CommentServlet.java
@@ -9,7 +9,6 @@ import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.Filter;
 import com.google.appengine.api.datastore.Query.FilterOperator;
 import com.google.appengine.api.datastore.Query.FilterPredicate;
-import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
 import com.google.gson.Gson;
@@ -17,6 +16,7 @@ import com.google.sps.ServletHelpers;
 import com.google.sps.data.Comment;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
@@ -35,7 +35,7 @@ public class CommentServlet extends HttpServlet {
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     UserService userService = UserServiceFactory.getUserService();
     String email = userService.getCurrentUser().getEmail();
-    Query query = new Query("Review-comments").addSort("date", SortDirection.DESCENDING);
+    Query query = new Query("Review-comments");
     Filter emailFilter = new FilterPredicate("reviewee", FilterOperator.EQUAL, email);
     query.setFilter(emailFilter);
 
@@ -61,6 +61,7 @@ public class CommentServlet extends HttpServlet {
       comments.add(new Comment(reviewer, reviewee, text, type, date, id));
     }
 
+    Collections.sort(comments, Comment.ORDER_BY_DATE);
     Gson gson = new Gson();
 
     response.setContentType("application/json;");


### PR DESCRIPTION
When I deployed our previous version of ResumeBuddy, the comments were not loading on the page because there was an error with sort and filtering queries at the same time. To fix this, I only filtered the query and then sorted the array of comments later by implementing a Comparator.