### PR TITLE
Reviewer can see Reviewee's Resume

### DIFF
--- a/resume-buddy/src/main/java/com/google/sps/servlets/BlobstoreServeServlet.java
+++ b/resume-buddy/src/main/java/com/google/sps/servlets/BlobstoreServeServlet.java
@@ -22,13 +22,13 @@ public class BlobstoreServeServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    // Gets the logged in user's email, finds the PDF blob and serves it
+    // Gets the logged in user's email, finds the PDF blob from the Match datastore and serves it
     UserService userService = UserServiceFactory.getUserService();
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     FetchOptions fetchOptions = FetchOptions.Builder.withLimit(Integer.MAX_VALUE);
     String email = userService.getCurrentUser().getEmail();
-    Query query = new Query("Match");
 
+    Query query = new Query("Match");
     PreparedQuery results = datastore.prepare(query);
     List<Entity> entityList = results.asList(fetchOptions);
     String userBlobKeyString = "";
@@ -39,7 +39,6 @@ public class BlobstoreServeServlet extends HttpServlet {
         userBlobKeyString = pair.getProperty("resumeBlobKey").toString();
       }
     }
-    //TODO: (sesexton) Included more logic if the user is both a reviewee and a reviewer
 
     BlobKey userBlobKey = new BlobKey(userBlobKeyString);
     blobstoreService.serve(userBlobKey, response);

--- a/resume-buddy/src/main/java/com/google/sps/servlets/BlobstoreServeServlet.java
+++ b/resume-buddy/src/main/java/com/google/sps/servlets/BlobstoreServeServlet.java
@@ -39,6 +39,7 @@ public class BlobstoreServeServlet extends HttpServlet {
         userBlobKeyString = pair.getProperty("resumeBlobKey").toString();
       }
     }
+    //TODO: (sesexton) Included more logic if the user is both a reviewee and a reviewer
 
     BlobKey userBlobKey = new BlobKey(userBlobKeyString);
     blobstoreService.serve(userBlobKey, response);

--- a/resume-buddy/src/main/java/com/google/sps/servlets/BlobstoreServeServlet.java
+++ b/resume-buddy/src/main/java/com/google/sps/servlets/BlobstoreServeServlet.java
@@ -30,25 +30,22 @@ public class BlobstoreServeServlet extends HttpServlet {
     String email = userService.getCurrentUser().getEmail();
 
     Query revieweeQuery = new Query("Match");
+    Query reviewerQuery = new Query("Match");
     Filter revieweeFilter = new FilterPredicate("reviewee", FilterOperator.EQUAL, email);
+    Filter reviewerFilter = new FilterPredicate("reviewer", FilterOperator.EQUAL, email);
     revieweeQuery.setFilter(revieweeFilter);
+    reviewerQuery.setFilter(reviewerFilter);
+    PreparedQuery reviewerResults = datastore.prepare(reviewerQuery);
     PreparedQuery revieweeResults = datastore.prepare(revieweeQuery);
+    String matchBlobKeyString = "";
 
     if (revieweeResults.countEntities(FetchOptions.Builder.withDefaults()) == 0) {
-      Query reviewerQuery = new Query("Match");
-      Filter reviewerFilter = new FilterPredicate("reviewer", FilterOperator.EQUAL, email);
-      reviewerQuery.setFilter(reviewerFilter);
-      PreparedQuery reviewerResults = datastore.prepare(reviewerQuery);
-      String reviewerBlobKeyString =
-          reviewerResults.asSingleEntity().getProperty("resumeBlobKey").toString();
-      BlobKey reviewerBlobKey = new BlobKey(reviewerBlobKeyString);
-      blobstoreService.serve(reviewerBlobKey, response);
-      return;
+      matchBlobKeyString = reviewerResults.asSingleEntity().getProperty("resumeBlobKey").toString();
+    } else {
+      matchBlobKeyString = revieweeResults.asSingleEntity().getProperty("resumeBlobKey").toString();
     }
 
-    String revieweeBlobKeyString =
-        revieweeResults.asSingleEntity().getProperty("resumeBlobKey").toString();
-    BlobKey revieweeBlobKey = new BlobKey(revieweeBlobKeyString);
-    blobstoreService.serve(revieweeBlobKey, response);
+    BlobKey matchBlobKey = new BlobKey(matchBlobKeyString);
+    blobstoreService.serve(matchBlobKey, response);
   }
 }

--- a/resume-buddy/src/main/webapp/scripts/resume-review-script.js
+++ b/resume-buddy/src/main/webapp/scripts/resume-review-script.js
@@ -91,6 +91,7 @@ async function getRevieweeResume() {
         metaData: {
           fileName: "revieweeResume.pdf"
         }
+        //TODO (sesexton): Add embed mode correctly
       }, {});
     });
 }

--- a/resume-buddy/src/main/webapp/scripts/resume-review-script.js
+++ b/resume-buddy/src/main/webapp/scripts/resume-review-script.js
@@ -77,7 +77,7 @@ async function getRevieweeResume() {
   fetch('/blobstore-serve')
     .then((response) => {
       var adobeDCView = new AdobeDC.View({
-        clientId: "b98bbf69d44442479396583253ac267c",
+        clientId: "",
         divId: "adobe-dc-view"
       });
       adobeDCView.previewFile({

--- a/resume-buddy/src/main/webapp/scripts/resume-review-script.js
+++ b/resume-buddy/src/main/webapp/scripts/resume-review-script.js
@@ -91,7 +91,7 @@ async function getRevieweeResume() {
         metaData: {
           fileName: "revieweeResume.pdf"
         }
-      }, {embedMode : "IN-LINE"});
+      }, {});
     });
 }
 

--- a/resume-buddy/src/main/webapp/scripts/resume-review-script.js
+++ b/resume-buddy/src/main/webapp/scripts/resume-review-script.js
@@ -77,6 +77,15 @@ function createListElement(date, type, text, id) {
 /**
  * Fetches the blobstore-serve to sends its response as an array buffer to the Adobe DC View
  */
+ const previewConfig={
+  "showLeftHandPanel":true,
+  "showPageControls":false,
+  "showDownloadPDF": false,
+  "showAnnotationTools": false,
+  "showPrintPDF": false,
+  "embedMode": "IN_LINE"
+}
+
 async function getRevieweeResume() {
   fetch('/blobstore-serve')
     .then((response) => {
@@ -90,10 +99,9 @@ async function getRevieweeResume() {
         },
         metaData: {
           fileName: "revieweeResume.pdf"
-        }
-        //TODO (sesexton): Add embed mode correctly
-      }, {});
-    });
+        }},
+    previewConfig);
+});
 }
 
  /*


### PR DESCRIPTION
This PR has the edits in `BlobStoreServe.java` Servlet that now obtains the blobstore key form the Match datastore, therefor you can only see your resume once you are matched.

I also had to remove the embed attribute in the adobe dc view cloud because it was giving some errors. I will readdress that in a secondary PR. This PR will close the Reviewer can see Matched Reviewee's Resume issue.