### PR TITLE
Check Reviewee & Reviewer then Send Blobkey

### DIFF
--- a/resume-buddy/src/main/java/com/google/sps/servlets/BlobstoreServeServlet.java
+++ b/resume-buddy/src/main/java/com/google/sps/servlets/BlobstoreServeServlet.java
@@ -46,11 +46,13 @@ public class BlobstoreServeServlet extends HttpServlet {
     int revieweeCount = revieweeResults.countEntities(FetchOptions.Builder.withDefaults());
     int reviewerCount = reviewerResults.countEntities(FetchOptions.Builder.withDefaults());
 
-    if (revieweeCount == 0 && reviewerCount > 0) {
+    if (revieweeCount == 0 && reviewerCount == 0) {
+      return;
+    } else if (reviewerCount > 0) {
       matchBlobKeyString = reviewerResults.asSingleEntity().getProperty("resumeBlobKey").toString();
       newResumeFileName = reviewerResults.asSingleEntity().getProperty("reviewee").toString();
       showAnnoTool = true;
-    } else if (revieweeCount > 0 && revieweeCount == 0) {
+    } else if (revieweeCount > 0) {
       matchBlobKeyString = revieweeResults.asSingleEntity().getProperty("resumeBlobKey").toString();
       newResumeFileName = revieweeResults.asSingleEntity().getProperty("reviewee").toString();
     }

--- a/resume-buddy/src/main/java/com/google/sps/servlets/BlobstoreServeServlet.java
+++ b/resume-buddy/src/main/java/com/google/sps/servlets/BlobstoreServeServlet.java
@@ -40,13 +40,17 @@ public class BlobstoreServeServlet extends HttpServlet {
     reviewerQuery.setFilter(reviewerFilter);
     PreparedQuery reviewerResults = datastore.prepare(reviewerQuery);
     PreparedQuery revieweeResults = datastore.prepare(revieweeQuery);
-    String matchBlobKeyString, newResumeFileName, showAnnoToolString = "";
+    String matchBlobKeyString = "";
+    String newResumeFileName = "";
+    String showAnnoToolString = "";
+    int revieweeCount = revieweeResults.countEntities(FetchOptions.Builder.withDefaults());
+    int reviewerCount = reviewerResults.countEntities(FetchOptions.Builder.withDefaults());
 
-    if (revieweeResults.countEntities(FetchOptions.Builder.withDefaults()) == 0) {
+    if (revieweeCount == 0 && reviewerCount > 0) {
       matchBlobKeyString = reviewerResults.asSingleEntity().getProperty("resumeBlobKey").toString();
       newResumeFileName = reviewerResults.asSingleEntity().getProperty("reviewee").toString();
       showAnnoTool = true;
-    } else {
+    } else if (revieweeCount > 0 && revieweeCount == 0) {
       matchBlobKeyString = revieweeResults.asSingleEntity().getProperty("resumeBlobKey").toString();
       newResumeFileName = revieweeResults.asSingleEntity().getProperty("reviewee").toString();
     }


### PR DESCRIPTION
This pr change alters the if-else statement to a if if-else statement so that now we are checking if the users email is not in the reviewee or the reviewer attribute in the match datastore, it will return an empty string instead of trying to return a resumeblobkey that does not exist and getting a nullpointer error.

Also fix the instantiation of the strings, because only the showAnnottoolString was being set to an empty string.