### PR TITLE
Enable ShowAnnotationTools for Reviewee

### DIFF
--- a/resume-buddy/src/main/java/com/google/sps/servlets/BlobstoreServeServlet.java
+++ b/resume-buddy/src/main/java/com/google/sps/servlets/BlobstoreServeServlet.java
@@ -42,7 +42,6 @@ public class BlobstoreServeServlet extends HttpServlet {
     PreparedQuery revieweeResults = datastore.prepare(revieweeQuery);
     String matchBlobKeyString = "";
     String resumeFileName = "";
-    String showAnnoToolString = "";
     int revieweeCount = revieweeResults.countEntities(FetchOptions.Builder.withDefaults());
     int reviewerCount = reviewerResults.countEntities(FetchOptions.Builder.withDefaults());
 
@@ -51,7 +50,6 @@ public class BlobstoreServeServlet extends HttpServlet {
     } else if (reviewerCount > 0) {
       matchBlobKeyString = reviewerResults.asSingleEntity().getProperty("resumeBlobKey").toString();
       resumeFileName = reviewerResults.asSingleEntity().getProperty("resumeFileName").toString();
-      showAnnoTool = true;
     } else if (revieweeCount > 0) {
       matchBlobKeyString = revieweeResults.asSingleEntity().getProperty("resumeBlobKey").toString();
       resumeFileName = revieweeResults.asSingleEntity().getProperty("resumeFileName").toString();
@@ -62,7 +60,6 @@ public class BlobstoreServeServlet extends HttpServlet {
     // Sets the blob key string as the response header so it can be set as the unquie pdf ID
     response.addHeader("blobKeyString", matchBlobKeyString);
     response.addHeader("resumeFileName", resumeFileName);
-    response.addHeader("annoToolBool", showAnnoToolString);
     blobstoreService.serve(matchBlobKey, response);
   }
 }

--- a/resume-buddy/src/main/webapp/scripts/resume-review-script.js
+++ b/resume-buddy/src/main/webapp/scripts/resume-review-script.js
@@ -116,7 +116,8 @@ const previewConfig = {
   showDownloadPDF: false,
   showPrintPDF: false,
   enableAnnotationsAPI: true,
-  includePDFAnnotations: true
+  includePDFAnnotations: true,
+  showAnnotationTools: true
 }
 
 /* Fetches the blobstore-serve to sends its response as an array buffer to the Adobe DC View */
@@ -125,8 +126,6 @@ async function getRevieweeResume() {
     .then((response) => {
       const pdfId = response.headers.get('blobKeyString');
       const resumeFileName = response.headers.get('resumeFileName');
-      const showAnnoTools = (response.headers.get('annoToolBool') === 'true');
-      previewConfig.showAnnotationTools = showAnnoTools;
       var adobeDCView = new AdobeDC.View({
         clientId: '',
         divId: 'adobe-dc-view'


### PR DESCRIPTION
In order for the reviewee to view comments from the reviewer, the ShowAnnotationsTool has to be enabled. I refactored the code the once used to disable it for reviewee, so now it is enable. Ani created a function that will save annotations form the reviewer as well as the reviewee so there shouldn't be a older versions of the pdf floating around.